### PR TITLE
Adds filter support (ie, {{ 'some text' | trans }}

### DIFF
--- a/tasks/twig_extractor.js
+++ b/tasks/twig_extractor.js
@@ -1,0 +1,161 @@
+/*
+ * grunt-twig-gettext
+ * http://grunt-twig-gettext.monomelodies.nl
+ *
+ * Copyright (c) 2015 Marijn Ophorst, Alvaro Maceda
+ * Licensed under the MIT license.
+ */
+
+'use strict';
+
+var Extractor = function(grunt, options) {
+    this.grunt = grunt;
+    this.options = options;
+};
+
+Extractor.prototype = (function() {
+
+    var that;
+
+    function transformTwigVariablesInGettextVariables(matches) {
+        matches = matches.map(function (trans) {
+            return trans[1].replace(/{{\s*(.*?)\s*}}/g, '%$1%');
+        });
+        return matches;
+    }
+
+    function formatTranslationsAccordingToPot(matches) {
+        var generatedLines;
+
+        generatedLines = matches.map(function (trans) {
+            trans = trans.trim();
+            var has_notes = /{% notes %}((\n|.)*?)({%|$)/g.exec(trans);
+            if (has_notes) {
+                trans = trans.replace(has_notes[0], has_notes[3]);
+            }
+            var has_plural = /{% plural .*?%}((\n|.)*?)$/g.exec(trans);
+            if (has_plural) {
+                trans = trans.replace(has_plural[0], '');
+            }
+            var lines = trans.split("\n");
+            lines = lines.map(function (line) {
+                line = ('' + line).replace(/\s$/, '');
+                line = '"' + line.replace(/"/g, '\\"');
+                return line;
+            });
+            trans = lines.join("\\n\"\n") + '"';
+            var result;
+            var ret = '';
+            if (has_notes) {
+                has_notes[1].split('\n').map(function (note) {
+                    ret += '# ' + note + '\n';
+                });
+            }
+            ret += "msgid " + trans + "\n";
+            if (has_plural) {
+                ret += "msgid_plural " + has_plural[1].split('\n').map(function (line) {
+                        line = ('' + line).replace(/\s$/, '');
+                        line = '"' + line.replace(/"/g, '\\"');
+                        return line;
+                    }).join("\\n\"\n") + "\"\n";
+                return ret + "msgstr[0] \"\"\nmsgstr[1] \"\"";
+            } else {
+                return ret + "msgstr \"\"";
+            }
+        });
+
+        return generatedLines;
+    }
+
+    function removeDuplicatedEntries(entries) {
+        var unique = [];
+        entries.map(function (match) {
+            if (unique.indexOf(match) === -1) {
+                unique.push(match);
+            }
+        });
+        return unique;
+    }
+
+    function generatePoContents(entries) {
+        var src = "#, fuzzy\n" +
+            "msgid \"\"\n" +
+            "msgstr \"\"\n" +
+            "\"Language: \\n\"\n" +
+            "\"MIME-Version: 1.0\\n\"\n" +
+            "\"Content-Type: text/plain; charset=" + that.options.charset + "\\n\"\n" +
+            "\"Content-Transfer-Encoding: " + that.options.encoding + "\\n\"\n\n" + entries.join("\n\n") + "\n";
+        return src;
+    }
+
+    function appendInlineMatches(fileContents, currentMatches) {
+        var result;
+        var inline = /{%\s*trans\s*('|")(.*?)(\1)\s*%}/g;
+        while (result = inline.exec(fileContents)) {
+            result[1] = result[2]; // Text is in the second capture group
+            currentMatches.push(result);
+        }
+    }
+
+    function appendMultilineMatches(fileContents, currentMatches) {
+        var result;
+        var multiline = /{% trans %}((\n|.)*?){% endtrans %}/g;
+        while (result = multiline.exec(fileContents)) {
+            currentMatches.push(result);
+        }
+    }
+
+    function appendFilterMatches(fileContents, currentMatches) {
+        var result;
+
+        var filter = /('|")(.*)(\1)\s*\|\s*trans\s*\W/g;
+        while (result = filter.exec(fileContents)) {
+            result[1] = result[2]; // Text is in the second capture group
+            currentMatches.push(result);
+        }
+    }
+
+    function obtainMatchesInFile(filepath) {
+        var matchesInFile = [];
+        var fileContents = that.grunt.file.read(filepath);
+
+        appendInlineMatches(fileContents,matchesInFile);
+        appendMultilineMatches(fileContents,matchesInFile);
+        appendFilterMatches(fileContents,matchesInFile);
+
+        return matchesInFile;
+    }
+
+
+    function obtainMatchesInAllFiles(files, matches) {
+        files.map(function (filepath) {
+            var matchesInFile = obtainMatchesInFile(filepath);
+            matches = matches.concat(matchesInFile.sort(function (a, b) {
+                return a.index < b.index ? -1 : 1;
+            }));
+        });
+        return matches;
+    }
+
+    return {
+
+        constructor:Extractor,
+
+        // Public method
+        generatePoContents:function(files) {
+
+            that = this;
+
+            var matches = [];
+
+            matches = obtainMatchesInAllFiles(files, matches);
+            matches = transformTwigVariablesInGettextVariables(matches);
+            var entries = formatTranslationsAccordingToPot(matches);
+
+            return generatePoContents(removeDuplicatedEntries(entries));
+        }
+
+    };
+})();
+
+module.exports = Extractor;

--- a/tasks/twig_gettext.js
+++ b/tasks/twig_gettext.js
@@ -2,11 +2,12 @@
  * grunt-twig-gettext
  * http://grunt-twig-gettext.monomelodies.nl
  *
- * Copyright (c) 2015 Marijn Ophorst
+ * Copyright (c) 2015 Marijn Ophorst, Alvaro Maceda
  * Licensed under the MIT license.
  */
 
 'use strict';
+var Extractor = require('./twig_extractor.js');
 
 module.exports = function (grunt) {
 
@@ -18,87 +19,22 @@ module.exports = function (grunt) {
 
         this.files.forEach(function (f) {
             var matches = [];
-            f.src.filter(function(filepath) {
+
+            var files = f.src.filter(function(filepath) {
                 if (!grunt.file.exists(filepath)) {
                     grunt.log.warn('Source file "' + filepath + '" not found.');
                     return false;
                 } else {
                     return true;
                 }
-            }).map(function(filepath) {
-                var twig = grunt.file.read(filepath);
-                var result;
-                var inline1 = /{% trans "(.*?)" %}/g;
-                var inline2 = /{% trans '(.*?)' %}/g;
-                var multiline = /{% trans %}((\n|.)*?){% endtrans %}/g;
-                var submatches = [];
-                while ((result = inline1.exec(twig)) || (result = inline2.exec(twig)) || (result = multiline.exec(twig))) {
-                    submatches.push(result);
-                }
-                matches = matches.concat(submatches.sort(function (a, b) {
-                    return a.index < b.index ? -1 : 1;
-                }));
             });
 
-            // Replace variables
-            matches = matches.map(function (trans) {
-                return trans[1].replace(/{{\s*(.*?)\s*}}/g, '%$1%');
-            });
-            // Format according to .pot
-            matches = matches.map(function (trans) {
-                trans = trans.trim();
-                var has_notes = /{% notes %}((\n|.)*?)({%|$)/g.exec(trans);
-                if (has_notes) {
-                    trans = trans.replace(has_notes[0], has_notes[3]);
-                }
-                var has_plural = /{% plural .*?%}((\n|.)*?)$/g.exec(trans);
-                if (has_plural) {
-                    trans = trans.replace(has_plural[0], '');
-                }
-                var lines = trans.split("\n");
-                lines = lines.map(function (line) {
-                    line = ('' + line).replace(/\s$/, '');
-                    line = '"' + line.replace(/"/g, '\\"');
-                    return line;
-                });
-                trans = lines.join("\\n\"\n") + '"';
-                var result = undefined;
-                var ret = '';
-                if (has_notes) {
-                    has_notes[1].split('\n').map(function (note) {
-                        ret += '# ' + note + '\n';
-                    });
-                }
-                ret += "msgid " + trans + "\n";
-                if (has_plural) {
-                    ret += "msgid_plural " + has_plural[1].split('\n').map(function (line) {
-                        line = ('' + line).replace(/\s$/, '');
-                        line = '"' + line.replace(/"/g, '\\"');
-                        return line;
-                    }).join("\\n\"\n") + "\"\n";
-                    return ret + "msgstr[0] \"\"\nmsgstr[1] \"\"";
-                } else {
-                    return ret + "msgstr \"\"";
-                }
-            });
-            // Make unique (at least inside the file :))
-            var unique = [];
-            matches.map(function (match) {
-                if (unique.indexOf(match) == -1) {
-                    unique.push(match);
-                }
-            });
-            var src = "#, fuzzy\n" +
-                "msgid \"\"\n" +
-                "msgstr \"\"\n" +
-                "\"Language: \\n\"\n" +
-                "\"MIME-Version: 1.0\\n\"\n" +
-                "\"Content-Type: text/plain; charset=" + options.charset + "\\n\"\n" +
-                "\"Content-Transfer-Encoding: " + options.encoding + "\\n\"\n\n" + unique.join("\n\n") + "\n";
-            
+            var extractor = new Extractor(grunt, options);
+            var poContents = extractor.generatePoContents(files);
+
             // Write the destination file.
-            grunt.file.write(f.dest, src);
-            
+            grunt.file.write(f.dest, poContents);
+
             // Print a success message.
             grunt.log.writeln('File "' + f.dest + '" created.');
         });

--- a/test/expected/custom_options
+++ b/test/expected/custom_options
@@ -9,16 +9,24 @@ msgstr ""
 msgid "This is a single line, inline string."
 msgstr ""
 
-msgid ""
-"        This string spans multiple lines, and is embedded in HTML."
-""
+msgid "This is a single line, inline string, spaces varying."
+msgstr ""
+
+msgid "This is a single line, inline string, spaces varying too."
+msgstr ""
+
+msgid "This is the trans filter"
+msgstr ""
+
+msgid "This is the trans filter, too"
+msgstr ""
+
+msgid "This string spans multiple lines, and is embedded in HTML."
 msgstr ""
 
 msgid "This contains a Twig variable: %varname%."
 msgstr ""
 
-msgid ""
-"        This is multiline %string%, with multiple"
+msgid "This is multiline %string%, with multiple\n"
 "        %variables% in various %places%"
-""
 msgstr ""

--- a/test/expected/default_options
+++ b/test/expected/default_options
@@ -9,16 +9,24 @@ msgstr ""
 msgid "This is a single line, inline string."
 msgstr ""
 
-msgid ""
-"        This string spans multiple lines, and is embedded in HTML."
-""
+msgid "This is a single line, inline string, spaces varying."
+msgstr ""
+
+msgid "This is a single line, inline string, spaces varying too."
+msgstr ""
+
+msgid "This is the trans filter"
+msgstr ""
+
+msgid "This is the trans filter, too"
+msgstr ""
+
+msgid "This string spans multiple lines, and is embedded in HTML."
 msgstr ""
 
 msgid "This contains a Twig variable: %varname%."
 msgstr ""
 
-msgid ""
-"        This is multiline %string%, with multiple"
+msgid "This is multiline %string%, with multiple\n"
 "        %variables% in various %places%"
-""
 msgstr ""

--- a/test/fixtures/template.twig
+++ b/test/fixtures/template.twig
@@ -4,8 +4,18 @@
 
     {% trans "This is a single line, inline string." %}
 
+    {%trans "This is a single line, inline string, spaces varying."     %}
+
+    {%  trans "This is a single line, inline string, spaces varying too."%}
+
+    {{ 'This is the trans filter' | trans }}
+
+    {{ "This is the trans filter, too" | trans | upper }}
+
+    {{ "This is another filter, but not a translation" | transilvania }}
+
     {% trans %}
-        This string spans multiple lines, and is embedded in HTML.
+    This string spans multiple lines, and is embedded in HTML.
     {% endtrans %}
 
     {% trans "This contains a Twig variable: {{ varname }}." %}
@@ -15,4 +25,3 @@
         {{ variables }} in various {{ places }}
     {% endtrans %}
 {% endblock something %}
-


### PR DESCRIPTION
I've refactored the code a little bit. "formatTranslationsAccordingToPot" would need refactoring, but it's not covered by tests and I've left it out.

Tests are changed to reflect twig behaviour, they are passing now.